### PR TITLE
Disable ESLint during builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
     images: {
         unoptimized: true,
     },
+    eslint: {
+        ignoreDuringBuilds: true,
+    }
 };
 
 export default nextConfig;


### PR DESCRIPTION
This update configures the Next.js project to ignore ESLint checks during builds. It adds a new eslint configuration option to the next.config.ts file to achieve this. This change aims to speed up the build process while maintaining code quality through local ESLint checks.