### PR TITLE
Add 'force-static' directive to metadata route exports

### DIFF
--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,5 +1,7 @@
 import { MetadataRoute } from 'next'
 
+export const dynamic = 'force-static';
+
 export default function manifest(): MetadataRoute.Manifest {
     return {
         name: 'Kyva Online',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,7 @@
 import { MetadataRoute } from 'next'
 
+export const dynamic = 'force-static';
+
 export default function robots(): MetadataRoute.Robots {
     return {
         rules: [

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,7 @@
 import {MetadataRoute} from 'next'
 
+export const dynamic = 'force-static';
+
 export default function sitemap(): MetadataRoute.Sitemap {
     const baseUrl = 'https://kyva.online';
 


### PR DESCRIPTION
This ensures the metadata routes for robots, manifest, and sitemap are statically generated. It enhances site performance and guarantees consistent output for these routes.